### PR TITLE
feat: split members tabs and refresh leaderboard

### DIFF
--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -113,6 +113,16 @@ const applicationTables = {
     .index("by_member", ["memberId"])
     .index("by_endpoint", ["endpoint"]),
 
+  muPoints: defineTable({
+    memberId: v.id("members"),
+    assignedByMemberId: v.id("members"),
+    points: v.number(),
+    reason: v.string(),
+    createdAt: v.number(),
+  })
+    .index("by_member", ["memberId"])
+    .index("by_assigned_by", ["assignedByMemberId"]),
+
   vendors: defineTable({
     name: v.string(),
   }).index("by_name", ["name"]),


### PR DESCRIPTION
## Summary
- restructure the members page into dedicated leaderboard, directory, and management tabs with role-aware visibility
- refresh the leaderboard UI with spotlight cards, animated stats, and progress bars for a more celebratory feel
- polish the μpoint detail modal to keep the award flow cohesive with the updated experience

## Testing
- npx tsc -p convex -noEmit --pretty false
- npx tsc -p . -noEmit --pretty false
- npx vite build
- npm run lint *(fails: `convex dev --once` prompts for Convex login in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cced1d1198832eb28e88ad454935f3