### PR TITLE
Add attendance leaderboard with dual recognition UI

### DIFF
--- a/src/components/members/helpers.ts
+++ b/src/components/members/helpers.ts
@@ -35,6 +35,26 @@ export function formatPoints(value: number) {
   });
 }
 
+export function formatDuration(durationMs: number) {
+  const totalMinutes = Math.floor(durationMs / (1000 * 60));
+  const hours = Math.floor(totalMinutes / 60);
+  const minutes = totalMinutes % 60;
+
+  if (hours === 0 && minutes === 0) {
+    return "0m";
+  }
+
+  if (hours === 0) {
+    return `${minutes}m`;
+  }
+
+  if (minutes === 0) {
+    return `${hours}h`;
+  }
+
+  return `${hours}h ${minutes}m`;
+}
+
 export function filterMembers<
   T extends { name: string; email: string; role: string },
 >(list: Array<T>, searchTerm: string, roleFilter: string): Array<T> {

--- a/src/components/members/types.ts
+++ b/src/components/members/types.ts
@@ -11,6 +11,18 @@ export type LeaderboardEntry = {
   profileImageUrl: string | null;
 };
 
+export type AttendanceLeaderboardEntry = {
+  memberId: Id<"members">;
+  name: string;
+  email: string;
+  role: "admin" | "lead" | "member";
+  totalDurationMs: number;
+  sessionsCount: number;
+  meetingsAttended: number;
+  lastAttendanceAt: number | null;
+  profileImageUrl: string | null;
+};
+
 export type BountyEntry = {
   _id: Id<"bounties">;
   title: string;


### PR DESCRIPTION
## Summary
- add a Convex query that aggregates attendance session durations per member for a new hours leaderboard
- surface attendance stats in the members page header alongside μpoints totals
- redesign the leaderboard tab to show μpoint legends and hours heroes side-by-side with special "double crown" flair

## Testing
- `npm run lint` *(fails: convex dev --once cannot reach backend releases in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68d128700864832ebf1cd0611ccff46e