### PR TITLE
Add attendance hours recognition to leaderboard

### DIFF
--- a/src/components/MembersPage.tsx
+++ b/src/components/MembersPage.tsx
@@ -111,6 +111,11 @@ export function MembersPage({ member }: MembersPageProps) {
         totalPoints: 0,
         totalAwards: 0,
         topMemberName: null as string | null,
+        totalAttendanceMs: 0,
+        topHoursMemberName: null as string | null,
+        topHoursMs: 0,
+        dualChampionId: null as Id<"members"> | null,
+        dualChampionName: null as string | null,
       };
     }
     const totalPoints = leaderboard.reduce(
@@ -121,9 +126,38 @@ export function MembersPage({ member }: MembersPageProps) {
       (sum, entry) => sum + entry.awardsCount,
       0
     );
+    const totalAttendanceMs = leaderboard.reduce(
+      (sum, entry) => sum + entry.totalAttendanceMs,
+      0
+    );
+    const topMember = leaderboard[0] ?? null;
     const topMemberName =
-      totalAwards > 0 && leaderboard[0] ? leaderboard[0].name : null;
-    return { totalPoints, totalAwards, topMemberName };
+      totalAwards > 0 && topMember ? topMember.name : null;
+    let topHoursEntry: LeaderboardEntry | null = null;
+    for (const entry of leaderboard) {
+      if (
+        !topHoursEntry ||
+        entry.totalAttendanceMs > topHoursEntry.totalAttendanceMs
+      ) {
+        topHoursEntry = entry;
+      }
+    }
+    const dualChampion =
+      topMember &&
+      topHoursEntry &&
+      topMember.memberId === topHoursEntry.memberId
+        ? topMember
+        : null;
+    return {
+      totalPoints,
+      totalAwards,
+      topMemberName,
+      totalAttendanceMs,
+      topHoursMemberName: topHoursEntry ? topHoursEntry.name : null,
+      topHoursMs: topHoursEntry ? topHoursEntry.totalAttendanceMs : 0,
+      dualChampionId: dualChampion ? dualChampion.memberId : null,
+      dualChampionName: dualChampion ? dualChampion.name : null,
+    };
   }, [leaderboard]);
 
   const selectedMember = selectedMemberId

--- a/src/components/members/types.ts
+++ b/src/components/members/types.ts
@@ -9,6 +9,8 @@ export type LeaderboardEntry = {
   awardsCount: number;
   lastAwardedAt: number | null;
   profileImageUrl: string | null;
+  totalAttendanceMs: number;
+  attendanceSessionsCount: number;
 };
 
 export type BountyEntry = {


### PR DESCRIPTION
## Summary
- aggregate attendance session durations in the leaderboard query so every entry includes total logged hours
- track new hours metadata in the members page to surface top hour leaders and highlight dual μpoint + hours champions
- refresh the leaderboard tab with hours stats, a dedicated hours hall of fame, dual-crown badges, and progress visuals that celebrate time logged alongside μpoints

## Testing
- `npm run lint` *(fails: `convex dev --once` cannot fetch backend releases in this environment)*
- `npx tsc -p convex -noEmit --pretty false`
- `npx tsc -p . -noEmit --pretty false`
- `npx vite build`


------
https://chatgpt.com/codex/tasks/task_e_68d128700864832ebf1cd0611ccff46e