### PR TITLE
Add attendance hours leaderboard and dual recognition

### DIFF
--- a/src/components/MembersPage.tsx
+++ b/src/components/MembersPage.tsx
@@ -3,7 +3,14 @@ import { useQuery, useMutation } from "convex/react";
 import { api } from "../../convex/_generated/api";
 import { type Id } from "../../convex/_generated/dataModel";
 import { toast } from "sonner";
-import { Users, ShieldCheck, Sparkles, PlusCircle, Trophy } from "lucide-react";
+import {
+  Users,
+  ShieldCheck,
+  Sparkles,
+  PlusCircle,
+  Trophy,
+  Timer,
+} from "lucide-react";
 import { Modal } from "./Modal";
 import { LeaderboardTab } from "./members/LeaderboardTab";
 import { DirectoryTab } from "./members/DirectoryTab";
@@ -12,6 +19,7 @@ import {
   formatAwardDate as formatAwardDateHelper,
   formatPoints as formatPointsHelper,
   filterMembers as filterMembersHelper,
+  formatHours as formatHoursHelper,
 } from "./members/helpers";
 import type { BountyBoardData, LeaderboardEntry } from "./members/types";
 import { MemberWithProfile } from "../lib/members";
@@ -51,6 +59,15 @@ export function MembersPage({ member }: MembersPageProps) {
     | LeaderboardEntry[]
     | undefined;
   const leaderboard = useMemo(() => leaderboardQuery ?? [], [leaderboardQuery]);
+  const totalAttendanceMs = useMemo(
+    () =>
+      leaderboard.reduce(
+        (sum, entry) => sum + entry.totalAttendanceMs,
+        0
+      ),
+    [leaderboard]
+  );
+  const totalAttendanceLabel = formatHoursHelper(totalAttendanceMs);
   const bountyBoardQuery = useQuery(api.bounties.getBounties) as
     | BountyBoardData
     | undefined;
@@ -138,6 +155,23 @@ export function MembersPage({ member }: MembersPageProps) {
     selectedMemberLeaderboardEntry?.awardsCount ?? 0;
   const selectedMemberTotalPoints =
     selectedMemberLeaderboardEntry?.totalPoints ?? 0;
+  const selectedMemberAttendanceMs =
+    selectedMemberLeaderboardEntry?.totalAttendanceMs ?? 0;
+  const selectedMemberAttendanceMeetings =
+    selectedMemberLeaderboardEntry?.attendanceMeetingsCount ?? 0;
+  const selectedMemberAttendanceSessions =
+    selectedMemberLeaderboardEntry?.attendanceSessionCount ?? 0;
+  const selectedMemberAttendanceLabel = formatHoursHelper(
+    selectedMemberAttendanceMs
+  );
+  const selectedMemberAttendanceSummary =
+    selectedMemberAttendanceMs > 0
+      ? `${selectedMemberAttendanceLabel} hours across ${selectedMemberAttendanceMeetings.toLocaleString()} ${
+          selectedMemberAttendanceMeetings === 1 ? "meeting" : "meetings"
+        } • ${selectedMemberAttendanceSessions.toLocaleString()} ${
+          selectedMemberAttendanceSessions === 1 ? "check-in" : "check-ins"
+        }`
+      : "no hours tracked just yet";
   const selectedMemberAwardsLabel =
     selectedMemberAwardsCount === 1 ? "award" : "awards";
 
@@ -353,6 +387,14 @@ export function MembersPage({ member }: MembersPageProps) {
                   μpoints
                 </p>
               </div>
+              <div>
+                <p className="text-3xl font-light text-emerald-300">
+                  {totalAttendanceLabel}h
+                </p>
+                <p className="text-xs text-text-dim uppercase tracking-widest">
+                  hours tracked
+                </p>
+              </div>
             </div>
           </div>
 
@@ -380,6 +422,7 @@ export function MembersPage({ member }: MembersPageProps) {
           currentMemberId={member._id}
           formatPoints={formatPoints}
           formatAwardDate={formatAwardDate}
+          formatHours={formatHoursHelper}
           canAwardPoints={canAwardPoints}
           bountyBoard={bountyBoard}
           members={members}
@@ -454,6 +497,10 @@ export function MembersPage({ member }: MembersPageProps) {
                         {selectedMember.email}
                       </p>
                     )}
+                    <p className="text-xs text-text-muted mt-3 flex items-center gap-2">
+                      <Timer size={14} className="text-emerald-300" />
+                      {selectedMemberAttendanceSummary}
+                    </p>
                   </div>
                 </div>
                 <div className="text-right">

--- a/src/components/members/helpers.ts
+++ b/src/components/members/helpers.ts
@@ -1,3 +1,5 @@
+export const MS_PER_HOUR = 60 * 60 * 1000;
+
 export function formatDateYMD(ts: number) {
   return new Date(ts)
     .toLocaleDateString("en-US", {
@@ -32,6 +34,25 @@ export function formatPoints(value: number) {
   return value.toLocaleString(undefined, {
     minimumFractionDigits,
     maximumFractionDigits: minimumFractionDigits,
+  });
+}
+
+export function msToHours(valueMs: number) {
+  return valueMs / MS_PER_HOUR;
+}
+
+export function formatHours(valueMs: number) {
+  const hours = msToHours(valueMs);
+  if (hours === 0) return "0";
+  const decimals = Number.isInteger(hours)
+    ? 0
+    : hours > 0 && hours < 1
+      ? 2
+      : 1;
+  const minimumFractionDigits = decimals === 0 ? 0 : 1;
+  return hours.toLocaleString(undefined, {
+    minimumFractionDigits,
+    maximumFractionDigits: decimals,
   });
 }
 

--- a/src/components/members/types.ts
+++ b/src/components/members/types.ts
@@ -9,6 +9,10 @@ export type LeaderboardEntry = {
   awardsCount: number;
   lastAwardedAt: number | null;
   profileImageUrl: string | null;
+  totalAttendanceMs: number;
+  attendanceSessionCount: number;
+  attendanceMeetingsCount: number;
+  lastAttendanceAt: number | null;
 };
 
 export type BountyEntry = {


### PR DESCRIPTION
## Summary
- compute attendance totals per member alongside mu points so hours can be surfaced on the leaderboard
- expand the members UI with hours tracked stats, double-crown recognition, and detailed attendance context in member modals
- add a dedicated attendance leaderboard section with cross-award badges and formatting utilities for hours

## Testing
- `npm run lint` *(fails: convex dev --once cannot fetch backend releases in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d128700864832ebf1cd0611ccff46e