### PR TITLE
Add attendance leaderboard alongside mu points

### DIFF
--- a/src/components/MembersPage.tsx
+++ b/src/components/MembersPage.tsx
@@ -3,7 +3,13 @@ import { useQuery, useMutation } from "convex/react";
 import { api } from "../../convex/_generated/api";
 import { type Id } from "../../convex/_generated/dataModel";
 import { toast } from "sonner";
-import { Users, ShieldCheck, Sparkles, PlusCircle, Trophy } from "lucide-react";
+import {
+  Users,
+  ShieldCheck,
+  Sparkles,
+  PlusCircle,
+  Trophy,
+} from "lucide-react";
 import { Modal } from "./Modal";
 import { LeaderboardTab } from "./members/LeaderboardTab";
 import { DirectoryTab } from "./members/DirectoryTab";
@@ -12,6 +18,7 @@ import {
   formatAwardDate as formatAwardDateHelper,
   formatPoints as formatPointsHelper,
   filterMembers as filterMembersHelper,
+  formatHours as formatHoursHelper,
 } from "./members/helpers";
 import type { BountyBoardData, LeaderboardEntry } from "./members/types";
 import { MemberWithProfile } from "../lib/members";
@@ -110,6 +117,8 @@ export function MembersPage({ member }: MembersPageProps) {
       return {
         totalPoints: 0,
         totalAwards: 0,
+        totalHours: 0,
+        totalMeetings: 0,
         topMemberName: null as string | null,
       };
     }
@@ -121,9 +130,17 @@ export function MembersPage({ member }: MembersPageProps) {
       (sum, entry) => sum + entry.awardsCount,
       0
     );
+    const totalHours = leaderboard.reduce(
+      (sum, entry) => sum + entry.totalHours,
+      0
+    );
+    const totalMeetings = leaderboard.reduce(
+      (sum, entry) => sum + entry.meetingsAttended,
+      0
+    );
     const topMemberName =
       totalAwards > 0 && leaderboard[0] ? leaderboard[0].name : null;
-    return { totalPoints, totalAwards, topMemberName };
+    return { totalPoints, totalAwards, totalHours, totalMeetings, topMemberName };
   }, [leaderboard]);
 
   const selectedMember = selectedMemberId
@@ -138,6 +155,12 @@ export function MembersPage({ member }: MembersPageProps) {
     selectedMemberLeaderboardEntry?.awardsCount ?? 0;
   const selectedMemberTotalPoints =
     selectedMemberLeaderboardEntry?.totalPoints ?? 0;
+  const selectedMemberTotalHours =
+    selectedMemberLeaderboardEntry?.totalHours ?? 0;
+  const selectedMemberMeetingsAttended =
+    selectedMemberLeaderboardEntry?.meetingsAttended ?? 0;
+  const selectedMemberLastAttendedAt =
+    selectedMemberLeaderboardEntry?.lastAttendedAt ?? null;
   const selectedMemberAwardsLabel =
     selectedMemberAwardsCount === 1 ? "award" : "awards";
 
@@ -183,6 +206,7 @@ export function MembersPage({ member }: MembersPageProps) {
   };
 
   const formatPoints = (value: number) => formatPointsHelper(value);
+  const formatHours = (value: number) => formatHoursHelper(value);
 
   const openMemberDetails = (id: Id<"members">) => {
     setSelectedMemberId(id);
@@ -336,7 +360,7 @@ export function MembersPage({ member }: MembersPageProps) {
                 celebrate wins, stay organized, and keep frc team 7157 buzzing.
               </p>
             </div>
-            <div className="flex flex-wrap gap-4 text-center">
+            <div className="grid grid-cols-2 gap-4 text-center sm:grid-cols-4">
               <div>
                 <p className="text-3xl font-light text-sunset-orange">
                   {members.length}
@@ -351,6 +375,22 @@ export function MembersPage({ member }: MembersPageProps) {
                 </p>
                 <p className="text-xs text-text-dim uppercase tracking-widest">
                   μpoints
+                </p>
+              </div>
+              <div>
+                <p className="text-3xl font-light text-accent-purple">
+                  {formatHours(leaderboardStats.totalHours)}
+                </p>
+                <p className="text-xs text-text-dim uppercase tracking-widest">
+                  hours logged
+                </p>
+              </div>
+              <div>
+                <p className="text-3xl font-light text-sunset-orange">
+                  {leaderboardStats.totalMeetings.toLocaleString()}
+                </p>
+                <p className="text-xs text-text-dim uppercase tracking-widest">
+                  check-ins
                 </p>
               </div>
             </div>
@@ -380,6 +420,7 @@ export function MembersPage({ member }: MembersPageProps) {
           currentMemberId={member._id}
           formatPoints={formatPoints}
           formatAwardDate={formatAwardDate}
+          formatHours={formatHours}
           canAwardPoints={canAwardPoints}
           bountyBoard={bountyBoard}
           members={members}
@@ -466,6 +507,26 @@ export function MembersPage({ member }: MembersPageProps) {
                   <p className="text-xs text-text-muted mt-1">
                     {selectedMemberAwardsCount.toLocaleString()}{" "}
                     {selectedMemberAwardsLabel}
+                  </p>
+                </div>
+              </div>
+              <div className="mt-4 grid grid-cols-1 gap-4 text-right sm:grid-cols-2">
+                <div>
+                  <p className="text-2xl font-light text-accent-purple">
+                    {formatHours(selectedMemberTotalHours)} hrs
+                  </p>
+                  <p className="text-xs text-text-dim uppercase tracking-widest">
+                    attendance logged
+                  </p>
+                </div>
+                <div>
+                  <p className="text-lg font-light text-text-primary">
+                    {selectedMemberMeetingsAttended.toLocaleString()} check-ins
+                  </p>
+                  <p className="text-xs text-text-muted mt-1">
+                    {selectedMemberLastAttendedAt
+                      ? `last seen ${formatHistoryDate(selectedMemberLastAttendedAt)}`
+                      : "no attendance tracked yet"}
                   </p>
                 </div>
               </div>

--- a/src/components/members/LeaderboardTab.tsx
+++ b/src/components/members/LeaderboardTab.tsx
@@ -9,6 +9,9 @@ import {
   Sparkles,
   Target,
   Trophy,
+  Clock,
+  Medal,
+  Timer,
 } from "lucide-react";
 import { toast } from "sonner";
 import { BountyBoardData, LeaderboardEntry, BountyEntry } from "./types";
@@ -16,6 +19,7 @@ import {
   formatDateTime,
   formatAwardDate as formatAwardDateFn,
   formatPoints as formatPointsFn,
+  formatHours as formatHoursFn,
 } from "./../members/helpers";
 import { MemberWithProfile } from "../../lib/members";
 import { ProfileAvatar } from "../ProfileAvatar";
@@ -25,12 +29,15 @@ export interface LeaderboardTabProps {
   leaderboardStats: {
     totalPoints: number;
     totalAwards: number;
+    totalHours: number;
+    totalMeetings: number;
     topMemberName: string | null;
   };
   onSelectMember: (memberId: Id<"members">) => void;
   currentMemberId: Id<"members">;
   formatPoints?: (value: number) => string;
   formatAwardDate?: (timestamp: number | null) => string;
+  formatHours?: (value: number) => string;
   canAwardPoints: boolean;
   bountyBoard: BountyBoardData;
   members: Array<MemberWithProfile>;
@@ -67,10 +74,67 @@ export function LeaderboardTab(props: LeaderboardTabProps) {
 
   const formatPoints = props.formatPoints ?? formatPointsFn;
   const formatAwardDate = props.formatAwardDate ?? formatAwardDateFn;
+  const formatHours = props.formatHours ?? formatHoursFn;
 
   const topThree = leaderboard.slice(0, 3);
   const rest = leaderboard.slice(3);
   const leaderPoints = leaderboard[0]?.totalPoints ?? 0;
+
+  const hoursLeaderboard = useMemo(
+    () =>
+      [...leaderboard].sort((a, b) => {
+        if (b.totalHours !== a.totalHours) {
+          return b.totalHours - a.totalHours;
+        }
+        const lastSeenDiff = (b.lastAttendedAt ?? 0) - (a.lastAttendedAt ?? 0);
+        if (lastSeenDiff !== 0) {
+          return lastSeenDiff;
+        }
+        return a.name.localeCompare(b.name);
+      }),
+    [leaderboard]
+  );
+
+  const hoursLeader = hoursLeaderboard[0];
+  const leaderHours = hoursLeader?.totalHours ?? 0;
+  const hoursTopThree = hoursLeaderboard.slice(0, 3);
+  const hoursRest = hoursLeaderboard.slice(3);
+  const hasAttendanceData = hoursLeaderboard.some(
+    (entry) => entry.totalHours > 0
+  );
+
+  const pointsRankMap = useMemo(() => {
+    const map = new Map<Id<"members">, number>();
+    leaderboard.forEach((entry, index) => {
+      map.set(entry.memberId, index + 1);
+    });
+    return map;
+  }, [leaderboard]);
+
+  const hoursRankMap = useMemo(() => {
+    const map = new Map<Id<"members">, number>();
+    hoursLeaderboard.forEach((entry, index) => {
+      map.set(entry.memberId, index + 1);
+    });
+    return map;
+  }, [hoursLeaderboard]);
+
+  const doubleChampionId =
+    leaderPoints > 0 &&
+    leaderHours > 0 &&
+    hoursLeader &&
+    leaderboard[0]?.memberId === hoursLeader.memberId
+      ? hoursLeader.memberId
+      : null;
+
+  const computeProgress = (value: number, leaderValue: number) => {
+    if (leaderValue <= 0) {
+      return value > 0 ? 100 : 0;
+    }
+    if (value <= 0) return 0;
+    const percentage = Math.round((value / leaderValue) * 100);
+    return Math.min(100, Math.max(6, percentage));
+  };
 
   const [isCreateModalOpen, setIsCreateModalOpen] = useState(false);
   const [newTitle, setNewTitle] = useState("");
@@ -143,18 +207,18 @@ export function LeaderboardTab(props: LeaderboardTabProps) {
           <div className="absolute -bottom-28 left-0 h-48 w-48 rounded-full bg-gradient-to-br from-accent-purple/40 via-indigo-400/30 to-transparent blur-3xl" />
         </div>
         <div className="relative z-10 flex flex-col md:flex-row md:items-center md:justify-between gap-6">
-          <div>
+          <div className="space-y-2">
             <div className="flex items-center gap-2 text-text-primary">
               <Trophy size={22} className="text-sunset-orange drop-shadow" />
               <h2 className="text-2xl font-light">μpoint leaderboard</h2>
             </div>
-            <p className="text-sm text-text-muted mt-2">
+            <p className="text-sm text-text-muted">
               {canAwardPoints
                 ? "tap a teammate to celebrate them with μpoints and peek at their highlight reel."
                 : "tap a teammate to explore their μpoint highlight reel."}
             </p>
           </div>
-          <div className="grid grid-cols-2 gap-4 text-center">
+          <div className="grid grid-cols-2 gap-4 text-center sm:grid-cols-4">
             <div>
               <p className="text-2xl font-light text-sunset-orange">
                 {formatPoints(leaderboardStats.totalPoints)}
@@ -171,14 +235,59 @@ export function LeaderboardTab(props: LeaderboardTabProps) {
                 recognitions logged
               </p>
             </div>
+            <div>
+              <p className="text-2xl font-light text-accent-purple">
+                {formatHours(leaderboardStats.totalHours)}
+              </p>
+              <p className="text-xs text-text-dim uppercase tracking-widest">
+                hours tracked
+              </p>
+            </div>
+            <div>
+              <p className="text-2xl font-light text-sunset-orange">
+                {leaderboardStats.totalMeetings.toLocaleString()}
+              </p>
+              <p className="text-xs text-text-dim uppercase tracking-widest">
+                check-ins logged
+              </p>
+            </div>
           </div>
         </div>
-        {leaderboardStats.topMemberName && (
-          <div className="relative z-10 mt-4 text-sm text-text-muted">
-            🏆 leading the charge:{" "}
-            <span className="text-text-primary">
-              {leaderboardStats.topMemberName}
-            </span>
+        {(leaderboardStats.topMemberName || leaderHours > 0) && (
+          <div className="relative z-10 mt-4 text-sm text-text-muted space-y-1 md:space-y-0 md:flex md:flex-wrap md:items-center md:gap-4">
+            {doubleChampionId ? (
+              <span className="inline-flex items-center gap-2 text-yellow-200">
+                <Sparkles size={16} className="text-yellow-300 drop-shadow" />
+                <span>
+                  double crown:
+                  <span className="text-text-primary">
+                    {hoursLeader?.name ?? leaderboardStats.topMemberName}
+                  </span>
+                  {" "}reigns over μpoints and hours!
+                </span>
+              </span>
+            ) : (
+              <>
+                {leaderboardStats.topMemberName && (
+                  <span>
+                    🏆 leading μpoints:
+                    <span className="text-text-primary">
+                      {" "}
+                      {leaderboardStats.topMemberName}
+                    </span>
+                  </span>
+                )}
+                {leaderHours > 0 && hoursLeader?.name && (
+                  <span>
+                    ⏱ hours hero:
+                    <span className="text-text-primary">
+                      {" "}
+                      {hoursLeader.name}
+                    </span>
+                  </span>
+                )}
+              </>
+            )}
           </div>
         )}
       </div>
@@ -195,45 +304,36 @@ export function LeaderboardTab(props: LeaderboardTabProps) {
           {topThree.length > 0 && (
             <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
               {topThree.map((entry, index) => (
-                <SpotlightCard
+                <PointsSpotlightCard
                   key={entry.memberId}
                   entry={entry}
                   index={index}
                   formatPoints={formatPoints}
+                  formatHours={formatHours}
                   formatAwardDate={formatAwardDate}
                   isYou={entry.memberId === currentMemberId}
+                  hoursRank={hoursRankMap.get(entry.memberId)}
+                  isDoubleChampion={entry.memberId === doubleChampionId}
                   onSelect={() => onSelectMember(entry.memberId)}
                 />
               ))}
             </div>
           )}
 
-          <OpenBountiesSection
-            bountyBoard={bountyBoard}
-            canManageBounties={canManageBounties}
-            formatPoints={formatPoints}
-            onClickCreate={() => setIsCreateModalOpen(true)}
-            onClickComplete={(b) => {
-              setSelectedBounty(b);
-              setSelectedMemberId(null);
-              setCompletionNotes("");
-            }}
-          />
-
           {rest.length > 0 && (
             <div className="space-y-3">
               {rest.map((entry, index) => {
                 const absoluteRank = index + topThree.length;
-                const progressRaw = leaderPoints
-                  ? Math.min(
-                      100,
-                      Math.max(
-                        6,
-                        Math.round((entry.totalPoints / leaderPoints) * 100)
-                      )
-                    )
-                  : 0;
-                const progressWidth = `${progressRaw}%`;
+                const pointsProgress = computeProgress(
+                  entry.totalPoints,
+                  leaderPoints
+                );
+                const hoursProgress = computeProgress(
+                  entry.totalHours,
+                  leaderHours
+                );
+                const hoursRank = hoursRankMap.get(entry.memberId);
+                const isDoubleChampion = entry.memberId === doubleChampionId;
                 return (
                   <button
                     key={entry.memberId}
@@ -241,7 +341,13 @@ export function LeaderboardTab(props: LeaderboardTabProps) {
                     onClick={() => onSelectMember(entry.memberId)}
                     className="w-full text-left"
                   >
-                    <div className="card-modern hover:-translate-y-1 transition-transform">
+                    <div
+                      className={clsx(
+                        "card-modern hover:-translate-y-1 transition-transform",
+                        isDoubleChampion &&
+                          "border border-yellow-300/40 shadow-[0_0_26px_rgba(250,204,21,0.25)]"
+                      )}
+                    >
                       <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
                         <div className="flex items-start gap-4">
                           <div className="flex items-center gap-3">
@@ -265,6 +371,12 @@ export function LeaderboardTab(props: LeaderboardTabProps) {
                                   you
                                 </span>
                               )}
+                              {isDoubleChampion && <DoubleChampionBadge />}
+                              {!isDoubleChampion &&
+                                hoursRank !== undefined &&
+                                hoursRank <= 3 && (
+                                  <HoursBadge rank={hoursRank} />
+                                )}
                             </div>
                             <p className="text-sm text-text-muted">
                               {entry.email}
@@ -274,22 +386,59 @@ export function LeaderboardTab(props: LeaderboardTabProps) {
                                 ? "no μpoints yet"
                                 : `${entry.awardsCount} ${entry.awardsCount === 1 ? "award" : "awards"} • last awarded ${formatAwardDate(entry.lastAwardedAt)}`}
                             </p>
+                            <p className="text-xs text-text-dim mt-1">
+                              {entry.meetingsAttended === 0
+                                ? "no attendance recorded yet"
+                                : `${entry.meetingsAttended.toLocaleString()} ${
+                                    entry.meetingsAttended === 1
+                                      ? "check-in"
+                                      : "check-ins"
+                                  } • last seen ${
+                                    entry.lastAttendedAt
+                                      ? formatAwardDate(entry.lastAttendedAt)
+                                      : "recently"
+                                  }`}
+                            </p>
                           </div>
                         </div>
-                        <div className="text-right">
-                          <p className="text-2xl font-light text-sunset-orange">
-                            +{formatPoints(entry.totalPoints)}
-                          </p>
-                          <p className="text-xs text-text-dim uppercase tracking-widest mt-1">
-                            total μpoints
-                          </p>
+                        <div className="flex flex-col items-end gap-2 text-right">
+                          <div>
+                            <p className="text-2xl font-light text-sunset-orange">
+                              +{formatPoints(entry.totalPoints)}
+                            </p>
+                            <p className="text-xs text-text-dim uppercase tracking-widest mt-1">
+                              total μpoints
+                            </p>
+                          </div>
+                          <div className="inline-flex items-center gap-2 rounded-full bg-accent-purple/15 border border-accent-purple/30 px-3 py-1 text-xs text-accent-purple">
+                            <Clock size={14} className="text-accent-purple" />
+                            <span>{formatHours(entry.totalHours)} hrs</span>
+                          </div>
                         </div>
                       </div>
-                      <div className="mt-4 h-2 rounded-full bg-white/10 overflow-hidden">
-                        <div
-                          className="h-full bg-gradient-to-r from-sunset-orange via-amber-400 to-accent-purple"
-                          style={{ width: progressWidth }}
-                        />
+                      <div className="mt-4 space-y-2">
+                        <div className="h-2 rounded-full bg-white/10 overflow-hidden">
+                          <div
+                            className="h-full bg-gradient-to-r from-sunset-orange via-amber-400 to-accent-purple"
+                            style={{ width: `${pointsProgress}%` }}
+                          />
+                        </div>
+                        <div className="flex justify-between text-[10px] uppercase tracking-widest text-text-dim">
+                          <span>μpoints rank</span>
+                          <span>#{absoluteRank + 1}</span>
+                        </div>
+                        <div className="h-1.5 rounded-full bg-white/5 overflow-hidden">
+                          <div
+                            className="h-full bg-gradient-to-r from-accent-purple via-indigo-400 to-sky-400"
+                            style={{ width: `${hoursProgress}%` }}
+                          />
+                        </div>
+                        <div className="flex justify-between text-[10px] uppercase tracking-widest text-text-dim">
+                          <span>hours rank</span>
+                          <span>
+                            {hoursRank !== undefined ? `#${hoursRank}` : "—"}
+                          </span>
+                        </div>
                       </div>
                     </div>
                   </button>
@@ -297,6 +446,189 @@ export function LeaderboardTab(props: LeaderboardTabProps) {
               })}
             </div>
           )}
+
+          <div className="mt-10 space-y-4">
+            <div className="flex flex-col md:flex-row md:items-center md:justify-between gap-3">
+              <div className="flex items-center gap-2 text-text-primary">
+                <Clock size={20} className="text-accent-purple" />
+                <h3 className="text-xl font-light">attendance all-stars</h3>
+              </div>
+              {hasAttendanceData && leaderHours > 0 && (
+                <div className="text-xs md:text-sm text-text-muted uppercase tracking-widest">
+                  pace setter: {formatHours(leaderHours)} hrs
+                </div>
+              )}
+            </div>
+
+            {!hasAttendanceData ? (
+              <div className="glass-panel p-6 text-center text-text-muted">
+                once meetings are tracked, the attendance leaderboard will shine here.
+              </div>
+            ) : (
+              <>
+                <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+                  {hoursTopThree.map((entry, index) => (
+                    <HoursSpotlightCard
+                      key={entry.memberId}
+                      entry={entry}
+                      index={index}
+                      formatHours={formatHours}
+                      formatPoints={formatPoints}
+                      formatAwardDate={formatAwardDate}
+                      isYou={entry.memberId === currentMemberId}
+                      pointsRank={pointsRankMap.get(entry.memberId)}
+                      isDoubleChampion={entry.memberId === doubleChampionId}
+                      onSelect={() => onSelectMember(entry.memberId)}
+                    />
+                  ))}
+                </div>
+
+                {hoursRest.length > 0 && (
+                  <div className="space-y-3">
+                    {hoursRest.map((entry, index) => {
+                      const absoluteRank = index + hoursTopThree.length;
+                      const hoursProgress = computeProgress(
+                        entry.totalHours,
+                        leaderHours
+                      );
+                      const pointsProgress = computeProgress(
+                        entry.totalPoints,
+                        leaderPoints
+                      );
+                      const pointsRank = pointsRankMap.get(entry.memberId);
+                      const isDoubleChampion =
+                        entry.memberId === doubleChampionId;
+                      return (
+                        <button
+                          key={entry.memberId}
+                          type="button"
+                          onClick={() => onSelectMember(entry.memberId)}
+                          className="w-full text-left"
+                        >
+                          <div
+                            className={clsx(
+                              "card-modern hover:-translate-y-1 transition-transform",
+                              isDoubleChampion &&
+                                "border border-yellow-300/40 shadow-[0_0_26px_rgba(250,204,21,0.25)]"
+                            )}
+                          >
+                            <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
+                              <div className="flex items-start gap-4">
+                                <div className="flex items-center gap-3">
+                                  <div className="h-12 w-12 rounded-2xl bg-gradient-to-br from-glass via-white/10 to-transparent border border-white/10 flex items-center justify-center text-sm font-semibold text-text-secondary">
+                                    ⏱#{absoluteRank + 1}
+                                  </div>
+                                  <ProfileAvatar
+                                    name={entry.name}
+                                    imageUrl={entry.profileImageUrl}
+                                    size="lg"
+                                    className="border border-white/20"
+                                  />
+                                </div>
+                                <div>
+                                  <div className="flex items-center gap-2 flex-wrap text-text-primary">
+                                    <h4 className="font-light text-lg">
+                                      {entry.name}
+                                    </h4>
+                                    {entry.memberId === currentMemberId && (
+                                      <span className="text-xs text-sunset-orange bg-sunset-orange-dim px-2 py-0.5 rounded-full">
+                                        you
+                                      </span>
+                                    )}
+                                    {isDoubleChampion && <DoubleChampionBadge />}
+                                    {!isDoubleChampion &&
+                                      pointsRank !== undefined &&
+                                      pointsRank <= 3 && (
+                                        <PointsBadge rank={pointsRank} />
+                                      )}
+                                  </div>
+                                  <p className="text-sm text-text-muted">
+                                    {entry.email}
+                                  </p>
+                                  <p className="text-xs text-text-dim mt-1">
+                                    {entry.meetingsAttended === 0
+                                      ? "no attendance recorded yet"
+                                      : `${entry.meetingsAttended.toLocaleString()} ${
+                                          entry.meetingsAttended === 1
+                                            ? "check-in"
+                                            : "check-ins"
+                                        } • last seen ${
+                                          entry.lastAttendedAt
+                                            ? formatAwardDate(entry.lastAttendedAt)
+                                            : "recently"
+                                        }`}
+                                  </p>
+                                  <p className="text-xs text-text-dim mt-1">
+                                    {entry.totalPoints === 0
+                                      ? "no μpoints yet"
+                                      : `${formatPoints(entry.totalPoints)} μpoints • points rank ${
+                                          pointsRank ? `#${pointsRank}` : "—"
+                                        }`}
+                                  </p>
+                                </div>
+                              </div>
+                              <div className="flex flex-col items-end gap-2 text-right">
+                                <div>
+                                  <p className="text-2xl font-light text-accent-purple">
+                                    {formatHours(entry.totalHours)} hrs
+                                  </p>
+                                  <p className="text-xs text-text-dim uppercase tracking-widest mt-1">
+                                    attendance logged
+                                  </p>
+                                </div>
+                                <div className="inline-flex items-center gap-2 rounded-full bg-sunset-orange/15 border border-sunset-orange/30 px-3 py-1 text-xs text-sunset-orange">
+                                  <Timer size={14} className="text-sunset-orange" />
+                                  <span>
+                                    {entry.meetingsAttended.toLocaleString()} check-ins
+                                  </span>
+                                </div>
+                              </div>
+                            </div>
+                            <div className="mt-4 space-y-2">
+                              <div className="h-2 rounded-full bg-white/10 overflow-hidden">
+                                <div
+                                  className="h-full bg-gradient-to-r from-accent-purple via-indigo-400 to-sky-400"
+                                  style={{ width: `${hoursProgress}%` }}
+                                />
+                              </div>
+                              <div className="flex justify-between text-[10px] uppercase tracking-widest text-text-dim">
+                                <span>hours rank</span>
+                                <span>#{absoluteRank + 1}</span>
+                              </div>
+                              <div className="h-1.5 rounded-full bg-white/5 overflow-hidden">
+                                <div
+                                  className="h-full bg-gradient-to-r from-sunset-orange via-amber-400 to-accent-purple"
+                                  style={{ width: `${pointsProgress}%` }}
+                                />
+                              </div>
+                              <div className="flex justify-between text-[10px] uppercase tracking-widest text-text-dim">
+                                <span>μpoints rank</span>
+                                <span>
+                                  {pointsRank !== undefined ? `#${pointsRank}` : "—"}
+                                </span>
+                              </div>
+                            </div>
+                          </div>
+                        </button>
+                      );
+                    })}
+                  </div>
+                )}
+              </>
+            )}
+          </div>
+
+          <OpenBountiesSection
+            bountyBoard={bountyBoard}
+            canManageBounties={canManageBounties}
+            formatPoints={formatPoints}
+            onClickCreate={() => setIsCreateModalOpen(true)}
+            onClickComplete={(b) => {
+              setSelectedBounty(b);
+              setSelectedMemberId(null);
+              setCompletionNotes("");
+            }}
+          />
         </>
       )}
 
@@ -454,19 +786,25 @@ export function LeaderboardTab(props: LeaderboardTabProps) {
   );
 }
 
-function SpotlightCard({
+function PointsSpotlightCard({
   entry,
   index,
   formatPoints,
+  formatHours,
   formatAwardDate,
   isYou,
+  hoursRank,
+  isDoubleChampion,
   onSelect,
 }: {
   entry: LeaderboardEntry;
   index: number;
   formatPoints: (value: number) => string;
+  formatHours: (value: number) => string;
   formatAwardDate: (timestamp: number | null) => string;
   isYou: boolean;
+  hoursRank: number | undefined;
+  isDoubleChampion: boolean;
   onSelect: () => void;
 }) {
   const backgroundClass = getSpotlightBackground(index);
@@ -498,18 +836,35 @@ function SpotlightCard({
                 <span className="badge bg-black/40 border-white/20 text-white">
                   #{index + 1}
                 </span>
-              {isYou && (
-                <span className="text-xs bg-white/30 text-white px-2 py-0.5 rounded-full">
-                  you
-                </span>
-              )}
-            </div>
-            <p className="text-sm text-white/70 mt-1">{entry.email}</p>
-            <p className="text-xs text-white/60 mt-2">
-              {entry.awardsCount === 0
-                ? "no μpoints yet"
-                : `${entry.awardsCount} ${entry.awardsCount === 1 ? "award" : "awards"} • last awarded ${formatAwardDate(entry.lastAwardedAt)}`}
-            </p>
+                {isYou && (
+                  <span className="text-xs bg-white/30 text-white px-2 py-0.5 rounded-full">
+                    you
+                  </span>
+                )}
+                {isDoubleChampion && <DoubleChampionBadge variant="inverse" />}
+                {!isDoubleChampion &&
+                  hoursRank !== undefined &&
+                  hoursRank <= 3 && (
+                    <HoursBadge rank={hoursRank} variant="inverse" />
+                  )}
+              </div>
+              <p className="text-sm text-white/70 mt-1">{entry.email}</p>
+              <p className="text-xs text-white/60 mt-2">
+                {entry.awardsCount === 0
+                  ? "no μpoints yet"
+                  : `${entry.awardsCount} ${entry.awardsCount === 1 ? "award" : "awards"} • last awarded ${formatAwardDate(entry.lastAwardedAt)}`}
+              </p>
+              <p className="text-xs text-white/60 mt-1">
+                {entry.meetingsAttended === 0
+                  ? "no attendance recorded yet"
+                  : `${entry.meetingsAttended.toLocaleString()} ${
+                      entry.meetingsAttended === 1 ? "check-in" : "check-ins"
+                    } • last seen ${
+                      entry.lastAttendedAt
+                        ? formatAwardDate(entry.lastAttendedAt)
+                        : "recently"
+                    }`}
+              </p>
             </div>
           </div>
           {index === 0 ? (
@@ -518,16 +873,194 @@ function SpotlightCard({
             <Trophy size={28} className="text-white/80" />
           )}
         </div>
-        <div>
-          <p className="text-4xl font-light drop-shadow-lg">
-            +{formatPoints(entry.totalPoints)}
-          </p>
-          <p className="text-xs uppercase tracking-widest text-white/70 mt-1">
-            total μpoints
-          </p>
+        <div className="space-y-3">
+          <div>
+            <p className="text-4xl font-light drop-shadow-lg">
+              +{formatPoints(entry.totalPoints)}
+            </p>
+            <p className="text-xs uppercase tracking-widest text-white/70 mt-1">
+              total μpoints
+            </p>
+          </div>
+          <div className="inline-flex items-center gap-2 rounded-full bg-white/10 border border-white/20 px-3 py-1 text-sm">
+            <Clock size={16} className="text-amber-200" />
+            <span>{formatHours(entry.totalHours)} hrs logged</span>
+          </div>
         </div>
       </div>
     </button>
+  );
+}
+
+function HoursSpotlightCard({
+  entry,
+  index,
+  formatHours,
+  formatPoints,
+  formatAwardDate,
+  isYou,
+  pointsRank,
+  isDoubleChampion,
+  onSelect,
+}: {
+  entry: LeaderboardEntry;
+  index: number;
+  formatHours: (value: number) => string;
+  formatPoints: (value: number) => string;
+  formatAwardDate: (timestamp: number | null) => string;
+  isYou: boolean;
+  pointsRank: number | undefined;
+  isDoubleChampion: boolean;
+  onSelect: () => void;
+}) {
+  const backgroundClass = getAttendanceSpotlightBackground(index);
+  const avatarClassName = clsx(
+    "border-2 border-white/50",
+    index === 0 && "border-amber-200/70 shadow-[0_0_26px_rgba(250,204,21,0.35)]",
+    index === 1 && "border-white/60 shadow-[0_0_22px_rgba(148,163,184,0.35)]",
+    index === 2 && "border-teal-300/70 shadow-[0_0_22px_rgba(45,212,191,0.35)]"
+  );
+  return (
+    <button
+      type="button"
+      onClick={onSelect}
+      className="relative overflow-hidden rounded-3xl border border-white/15 p-6 text-left transition-transform hover:-translate-y-1"
+    >
+      <div className={clsx("absolute inset-0 opacity-80", backgroundClass)} />
+      <div className="relative z-10 flex flex-col h-full justify-between gap-6 text-white">
+        <div className="flex items-start justify-between gap-4">
+          <div className="flex items-start gap-4">
+            <ProfileAvatar
+              name={entry.name}
+              imageUrl={entry.profileImageUrl}
+              size="xl"
+              className={avatarClassName}
+            />
+            <div>
+              <div className="flex items-center gap-2 flex-wrap">
+                <h4 className="text-xl font-light">{entry.name}</h4>
+                <span className="badge bg-black/40 border-white/20 text-white">
+                  ⏱ #{index + 1}
+                </span>
+                {isYou && (
+                  <span className="text-xs bg-white/30 text-white px-2 py-0.5 rounded-full">
+                    you
+                  </span>
+                )}
+                {isDoubleChampion && <DoubleChampionBadge variant="inverse" />}
+                {!isDoubleChampion &&
+                  pointsRank !== undefined &&
+                  pointsRank <= 3 && (
+                    <PointsBadge rank={pointsRank} variant="inverse" />
+                  )}
+              </div>
+              <p className="text-sm text-white/70 mt-1">{entry.email}</p>
+              <p className="text-xs text-white/60 mt-2">
+                {entry.meetingsAttended === 0
+                  ? "no attendance recorded yet"
+                  : `${entry.meetingsAttended.toLocaleString()} ${
+                      entry.meetingsAttended === 1 ? "check-in" : "check-ins"
+                    } • last seen ${
+                      entry.lastAttendedAt
+                        ? formatAwardDate(entry.lastAttendedAt)
+                        : "recently"
+                    }`}
+              </p>
+              <p className="text-xs text-white/60 mt-1">
+                {entry.totalPoints === 0
+                  ? "no μpoints yet"
+                  : `${formatPoints(entry.totalPoints)} μpoints earned`}
+              </p>
+            </div>
+          </div>
+          {index === 0 ? (
+            <Timer size={32} className="text-amber-200 drop-shadow-lg" />
+          ) : (
+            <Medal size={28} className="text-white/80" />
+          )}
+        </div>
+        <div className="space-y-3">
+          <div>
+            <p className="text-4xl font-light drop-shadow-lg">
+              {formatHours(entry.totalHours)} hrs
+            </p>
+            <p className="text-xs uppercase tracking-widest text-white/70 mt-1">
+              attendance logged
+            </p>
+          </div>
+          <div className="inline-flex items-center gap-2 rounded-full bg-white/10 border border-white/20 px-3 py-1 text-sm">
+            <Clock size={16} className="text-amber-200" />
+            <span>{entry.meetingsAttended.toLocaleString()} check-ins</span>
+          </div>
+        </div>
+      </div>
+    </button>
+  );
+}
+
+function DoubleChampionBadge({
+  variant = "default",
+}: {
+  variant?: "default" | "inverse";
+}) {
+  const base = "inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-[10px] font-semibold uppercase tracking-[0.2em]";
+  const palette =
+    variant === "inverse"
+      ? "bg-yellow-400/20 border border-yellow-200/60 text-yellow-100"
+      : "bg-yellow-500/15 border border-yellow-500/40 text-yellow-600";
+  const iconClass = variant === "inverse" ? "text-yellow-100" : "text-yellow-500";
+  return (
+    <span className={clsx(base, palette)}>
+      <Sparkles size={12} className={iconClass} /> double crown
+    </span>
+  );
+}
+
+function HoursBadge({
+  rank,
+  variant = "default",
+}: {
+  rank: number;
+  variant?: "default" | "inverse";
+}) {
+  const palette =
+    variant === "inverse"
+      ? "bg-white/20 border border-white/40 text-white"
+      : "bg-accent-purple/20 border border-accent-purple/40 text-accent-purple";
+  const iconClass = variant === "inverse" ? "text-white" : "text-accent-purple";
+  return (
+    <span
+      className={clsx(
+        "inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-[10px] uppercase tracking-[0.18em]",
+        palette
+      )}
+    >
+      <Clock size={12} className={iconClass} /> hours #{rank}
+    </span>
+  );
+}
+
+function PointsBadge({
+  rank,
+  variant = "default",
+}: {
+  rank: number;
+  variant?: "default" | "inverse";
+}) {
+  const palette =
+    variant === "inverse"
+      ? "bg-white/20 border border-white/40 text-white"
+      : "bg-sunset-orange/15 border border-sunset-orange/40 text-sunset-orange";
+  const iconClass = variant === "inverse" ? "text-white" : "text-sunset-orange";
+  return (
+    <span
+      className={clsx(
+        "inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-[10px] uppercase tracking-[0.18em]",
+        palette
+      )}
+    >
+      <Medal size={12} className={iconClass} /> μpoints #{rank}
+    </span>
   );
 }
 
@@ -623,6 +1156,19 @@ function OpenBountiesSection({
       )}
     </div>
   );
+}
+
+function getAttendanceSpotlightBackground(index: number) {
+  switch (index) {
+    case 0:
+      return "bg-gradient-to-br from-[#38bdf8]/70 via-[#6366f1]/60 to-transparent";
+    case 1:
+      return "bg-gradient-to-br from-white/70 via-white/30 to-transparent";
+    case 2:
+      return "bg-gradient-to-br from-[#2dd4bf]/70 via-[#22d3ee]/60 to-transparent";
+    default:
+      return "bg-gradient-to-br from-white/10 to-transparent";
+  }
 }
 
 function getSpotlightBackground(index: number) {

--- a/src/components/members/helpers.ts
+++ b/src/components/members/helpers.ts
@@ -35,6 +35,18 @@ export function formatPoints(value: number) {
   });
 }
 
+export function formatHours(value: number) {
+  if (!Number.isFinite(value) || value === 0) {
+    return "0";
+  }
+  const absValue = Math.abs(value);
+  const fractionDigits = absValue >= 100 ? 0 : absValue >= 10 ? 1 : 2;
+  return value.toLocaleString(undefined, {
+    minimumFractionDigits: fractionDigits,
+    maximumFractionDigits: fractionDigits,
+  });
+}
+
 export function filterMembers<
   T extends { name: string; email: string; role: string },
 >(list: Array<T>, searchTerm: string, roleFilter: string): Array<T> {

--- a/src/components/members/types.ts
+++ b/src/components/members/types.ts
@@ -9,6 +9,10 @@ export type LeaderboardEntry = {
   awardsCount: number;
   lastAwardedAt: number | null;
   profileImageUrl: string | null;
+  totalAttendanceMs: number;
+  totalHours: number;
+  meetingsAttended: number;
+  lastAttendedAt: number | null;
 };
 
 export type BountyEntry = {


### PR DESCRIPTION
## Summary
- extend the leaderboard query to aggregate attendance sessions and expose hours, meeting counts, and last seen timestamps per member
- surface teamwide and per-member attendance metrics on the members page, including hours/check-in tiles and modal highlights
- redesign the leaderboard tab with badges, dual progress indicators, and a dedicated attendance all-stars section alongside μpoint rankings

## Testing
- npm run lint *(fails: `convex dev --once` cannot download backend releases in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d128700864832ebf1cd0611ccff46e