### PR TITLE
Add rolling leaderboard filters

### DIFF
--- a/src/components/MembersPage.tsx
+++ b/src/components/MembersPage.tsx
@@ -21,7 +21,11 @@ import {
   filterMembers as filterMembersHelper,
   formatHours as formatHoursHelper,
 } from "./members/helpers";
-import type { BountyBoardData, LeaderboardEntry } from "./members/types";
+import type {
+  BountyBoardData,
+  LeaderboardEntry,
+  LeaderboardRange,
+} from "./members/types";
 import { MemberWithProfile } from "../lib/members";
 import { ProfileAvatar } from "./ProfileAvatar";
 
@@ -38,6 +42,8 @@ export function MembersPage({ member }: MembersPageProps) {
   const [awardPoints, setAwardPoints] = useState("1");
   const [awardReason, setAwardReason] = useState("");
   const [isAwarding, setIsAwarding] = useState(false);
+  const [leaderboardRange, setLeaderboardRange] =
+    useState<LeaderboardRange>("allTime");
 
   const [directorySearchTerm, setDirectorySearchTerm] = useState("");
   const [directoryRoleFilter, setDirectoryRoleFilter] = useState<string>("all");
@@ -55,10 +61,11 @@ export function MembersPage({ member }: MembersPageProps) {
     () => membersQuery ?? [],
     [membersQuery]
   );
-  const leaderboardQuery = useQuery(api.members.getLeaderboard) as
-    | LeaderboardEntry[]
-    | undefined;
+  const leaderboardQuery = useQuery(api.members.getLeaderboard, {
+    range: leaderboardRange,
+  }) as LeaderboardEntry[] | undefined;
   const leaderboard = useMemo(() => leaderboardQuery ?? [], [leaderboardQuery]);
+  const isLeaderboardLoading = leaderboardQuery === undefined;
   const totalAttendanceMs = useMemo(
     () =>
       leaderboard.reduce(
@@ -418,8 +425,11 @@ export function MembersPage({ member }: MembersPageProps) {
         <LeaderboardTab
           leaderboard={leaderboard}
           leaderboardStats={leaderboardStats}
+          leaderboardRange={leaderboardRange}
+          onSelectRange={setLeaderboardRange}
           onSelectMember={openMemberDetails}
           currentMemberId={member._id}
+          isLoading={isLeaderboardLoading}
           formatPoints={formatPoints}
           formatAwardDate={formatAwardDate}
           formatHours={formatHoursHelper}

--- a/src/components/members/types.ts
+++ b/src/components/members/types.ts
@@ -1,5 +1,7 @@
 import { type Id } from "../../../convex/_generated/dataModel";
 
+export type LeaderboardRange = "allTime" | "lastMonth" | "lastWeek";
+
 export type LeaderboardEntry = {
   memberId: Id<"members">;
   name: string;


### PR DESCRIPTION
## Summary
- add a range argument to the leaderboard query so totals can be limited to the last month or week
- surface a new range toggle on the leaderboard and show loading placeholders while refreshed data arrives
- request leaderboard data with the selected range from the members page and share the range type definition

## Testing
- `npm run lint` *(fails: prompts for Convex login credentials)*

------
https://chatgpt.com/codex/tasks/task_e_68de458e9dfc832ea2ad6785e7edbfc1