### PR TITLE
Handle leaderboard query errors gracefully

### DIFF
--- a/src/components/MembersPage.tsx
+++ b/src/components/MembersPage.tsx
@@ -21,7 +21,11 @@ import {
   filterMembers as filterMembersHelper,
   formatHours as formatHoursHelper,
 } from "./members/helpers";
-import type { BountyBoardData, LeaderboardEntry } from "./members/types";
+import type {
+  BountyBoardData,
+  LeaderboardEntry,
+  LeaderboardRange,
+} from "./members/types";
 import { MemberWithProfile } from "../lib/members";
 import { ProfileAvatar } from "./ProfileAvatar";
 
@@ -38,6 +42,8 @@ export function MembersPage({ member }: MembersPageProps) {
   const [awardPoints, setAwardPoints] = useState("1");
   const [awardReason, setAwardReason] = useState("");
   const [isAwarding, setIsAwarding] = useState(false);
+  const [leaderboardRange, setLeaderboardRange] =
+    useState<LeaderboardRange>("allTime");
 
   const [directorySearchTerm, setDirectorySearchTerm] = useState("");
   const [directoryRoleFilter, setDirectoryRoleFilter] = useState<string>("all");
@@ -55,10 +61,27 @@ export function MembersPage({ member }: MembersPageProps) {
     () => membersQuery ?? [],
     [membersQuery]
   );
-  const leaderboardQuery = useQuery(api.members.getLeaderboard) as
-    | LeaderboardEntry[]
-    | undefined;
+  type LeaderboardQueryArgs = { range?: LeaderboardRange };
+  const leaderboardArgs = useMemo<LeaderboardQueryArgs>(
+    () => (leaderboardRange === "allTime" ? {} : { range: leaderboardRange }),
+    [leaderboardRange]
+  );
+  let leaderboardError: Error | null = null;
+  let leaderboardQuery: LeaderboardEntry[] | undefined;
+  try {
+    leaderboardQuery = useQuery(
+      api.members.getLeaderboard,
+      leaderboardArgs
+    ) as LeaderboardEntry[] | undefined;
+  } catch (error) {
+    leaderboardError =
+      error instanceof Error
+        ? error
+        : new Error(error ? String(error) : "Unknown error");
+    leaderboardQuery = undefined;
+  }
   const leaderboard = useMemo(() => leaderboardQuery ?? [], [leaderboardQuery]);
+  const isLeaderboardLoading = leaderboardQuery === undefined && !leaderboardError;
   const totalAttendanceMs = useMemo(
     () =>
       leaderboard.reduce(
@@ -418,8 +441,12 @@ export function MembersPage({ member }: MembersPageProps) {
         <LeaderboardTab
           leaderboard={leaderboard}
           leaderboardStats={leaderboardStats}
+          leaderboardRange={leaderboardRange}
+          onSelectRange={setLeaderboardRange}
           onSelectMember={openMemberDetails}
           currentMemberId={member._id}
+          isLoading={isLeaderboardLoading}
+          errorMessage={leaderboardError?.message ?? null}
           formatPoints={formatPoints}
           formatAwardDate={formatAwardDate}
           formatHours={formatHoursHelper}

--- a/src/components/members/LeaderboardTab.tsx
+++ b/src/components/members/LeaderboardTab.tsx
@@ -14,7 +14,12 @@ import {
   Timer,
 } from "lucide-react";
 import { toast } from "sonner";
-import { BountyBoardData, LeaderboardEntry, BountyEntry } from "./types";
+import {
+  BountyBoardData,
+  LeaderboardEntry,
+  LeaderboardRange,
+  BountyEntry,
+} from "./types";
 import {
   formatDateTime,
   formatAwardDate as formatAwardDateFn,
@@ -31,8 +36,12 @@ export interface LeaderboardTabProps {
     totalAwards: number;
     topMemberName: string | null;
   };
+  leaderboardRange: LeaderboardRange;
+  onSelectRange: (range: LeaderboardRange) => void;
   onSelectMember: (memberId: Id<"members">) => void;
   currentMemberId: Id<"members">;
+  isLoading: boolean;
+  errorMessage: string | null;
   formatPoints?: (value: number) => string;
   formatAwardDate?: (timestamp: number | null) => string;
   formatHours?: (valueMs: number) => string;
@@ -58,8 +67,12 @@ export function LeaderboardTab(props: LeaderboardTabProps) {
   const {
     leaderboard,
     leaderboardStats,
+    leaderboardRange,
+    onSelectRange,
     onSelectMember,
     currentMemberId,
+    isLoading,
+    errorMessage,
     canAwardPoints,
     bountyBoard,
     members,
@@ -73,10 +86,22 @@ export function LeaderboardTab(props: LeaderboardTabProps) {
   const formatPoints = props.formatPoints ?? formatPointsFn;
   const formatAwardDate = props.formatAwardDate ?? formatAwardDateFn;
   const formatHours = props.formatHours ?? formatHoursFn;
+  const hasError = Boolean(errorMessage);
 
   const topThree = leaderboard.slice(0, 3);
   const rest = leaderboard.slice(3);
   const leaderPoints = leaderboard[0]?.totalPoints ?? 0;
+  const rangeOptions: Array<{ value: LeaderboardRange; label: string }> = [
+    { value: "allTime", label: "All time" },
+    { value: "lastMonth", label: "Last Month" },
+    { value: "lastWeek", label: "Last Week" },
+  ];
+  const rangeLabelMap: Record<LeaderboardRange, string> = {
+    allTime: "All time",
+    lastMonth: "Last 30 days",
+    lastWeek: "Last 7 days",
+  };
+  const selectedRangeLabel = rangeLabelMap[leaderboardRange] ?? "All time";
 
   const hoursLeaderboard = useMemo(() => {
     const sorted = [...leaderboard];
@@ -192,6 +217,17 @@ export function LeaderboardTab(props: LeaderboardTabProps) {
     }
   };
 
+  const showEmptyState = !isLoading && !hasError && leaderboard.length === 0;
+  const displayTotalPoints = isLoading || hasError
+    ? "—"
+    : formatPoints(leaderboardStats.totalPoints);
+  const displayTotalAwards = isLoading || hasError
+    ? "—"
+    : leaderboardStats.totalAwards.toLocaleString();
+  const displayAttendanceLabel = isLoading || hasError
+    ? "—"
+    : `${totalAttendanceLabel}h`;
+
   return (
     <div className="space-y-6">
       <div className="relative overflow-hidden glass-panel p-6">
@@ -211,30 +247,57 @@ export function LeaderboardTab(props: LeaderboardTabProps) {
                 : "tap a teammate to explore their μpoint highlight reel."}
             </p>
           </div>
-          <div className="grid grid-cols-1 sm:grid-cols-3 gap-4 text-center">
-            <div>
-              <p className="text-2xl font-light text-sunset-orange">
-                {formatPoints(leaderboardStats.totalPoints)}
-              </p>
-              <p className="text-xs text-text-dim uppercase tracking-widest">
-                μpoints awarded
-              </p>
+          <div className="flex flex-col items-stretch gap-4 sm:items-end">
+            <div className="inline-flex items-center justify-center gap-1 rounded-full border border-white/10 bg-white/5 p-1 text-xs">
+              {rangeOptions.map((option) => {
+                const isSelected = option.value === leaderboardRange;
+                return (
+                  <button
+                    key={option.value}
+                    type="button"
+                    onClick={() => {
+                      if (!isSelected) {
+                        onSelectRange(option.value);
+                      }
+                    }}
+                    className={clsx(
+                      "px-3 py-1 rounded-full transition-colors",
+                      isSelected
+                        ? "bg-white text-text-primary shadow-sm"
+                        : "text-text-muted hover:text-text-primary"
+                    )}
+                    aria-pressed={isSelected}
+                  >
+                    {option.label}
+                  </button>
+                );
+              })}
             </div>
-            <div>
-              <p className="text-2xl font-light text-accent-purple">
-                {leaderboardStats.totalAwards}
-              </p>
-              <p className="text-xs text-text-dim uppercase tracking-widest">
-                recognitions logged
-              </p>
-            </div>
-            <div>
-              <p className="text-2xl font-light text-emerald-300">
-                {totalAttendanceLabel}h
-              </p>
-              <p className="text-xs text-text-dim uppercase tracking-widest">
-                hours tracked
-              </p>
+            <div className="grid grid-cols-1 sm:grid-cols-3 gap-4 text-center">
+              <div>
+                <p className="text-2xl font-light text-sunset-orange">
+                  {displayTotalPoints}
+                </p>
+                <p className="text-xs text-text-dim uppercase tracking-widest">
+                  μpoints awarded • {selectedRangeLabel}
+                </p>
+              </div>
+              <div>
+                <p className="text-2xl font-light text-accent-purple">
+                  {displayTotalAwards}
+                </p>
+                <p className="text-xs text-text-dim uppercase tracking-widest">
+                  recognitions logged • {selectedRangeLabel}
+                </p>
+              </div>
+              <div>
+                <p className="text-2xl font-light text-emerald-300">
+                  {displayAttendanceLabel}
+                </p>
+                <p className="text-xs text-text-dim uppercase tracking-widest">
+                  hours tracked • {selectedRangeLabel}
+                </p>
+              </div>
             </div>
           </div>
         </div>
@@ -268,7 +331,16 @@ export function LeaderboardTab(props: LeaderboardTabProps) {
         )}
       </div>
 
-      {leaderboard.length === 0 ? (
+      {hasError ? (
+        <div className="glass-panel p-8 text-center">
+          <p className="text-text-muted">
+            we couldn't load the leaderboard just yet. try again in a moment.
+          </p>
+          <p className="text-xs text-text-dim mt-2 break-words">
+            {errorMessage}
+          </p>
+        </div>
+      ) : showEmptyState ? (
         <div className="glass-panel p-8 text-center">
           <p className="text-text-muted">
             no μpoints have been awarded yet. once recognitions are logged, the

--- a/src/components/members/types.ts
+++ b/src/components/members/types.ts
@@ -1,5 +1,7 @@
 import { type Id } from "../../../convex/_generated/dataModel";
 
+export type LeaderboardRange = "allTime" | "lastMonth" | "lastWeek";
+
 export type LeaderboardEntry = {
   memberId: Id<"members">;
   name: string;


### PR DESCRIPTION
## Summary
- wrap the leaderboard query in defensive error handling and only send the range filter when it changes
- surface query failures in the leaderboard tab so the UI shows a helpful message instead of crashing

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68de458e9dfc832ea2ad6785e7edbfc1